### PR TITLE
🚑 Fix : 새로 저장할 파일 이름 확장자 뒤에 붙는 오류 해결

### DIFF
--- a/src/components/UploadBox.jsx
+++ b/src/components/UploadBox.jsx
@@ -82,7 +82,8 @@ export default function UploadBox() {
     // a 태그를 생성하고 다운로드 링크로 사용
     const a = document.createElement("a");
     a.href = dataURL;
-    a.download = `${uploadedInfo.name}_time`; // 파일명
+    const renamedFile = uploadedInfo.name.split(".")[0] + "_time";
+    a.download = renamedFile; // 파일명
     a.click();
   };
 


### PR DESCRIPTION
## 변경 사항

- time이라는 단어를 붙여서 저장 시도 => 확장자 뒤에 붙는 버그 발생
- split 메서드를 이용해 확장자 자르고 리네이밍하는 식으로 해결